### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.git
+.vscode
+.idea
+dist
+coverage
+logs
+*.log
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ The server uses a feature-based architecture where each feature area (like work-
 
 ### Running with NPX
 
+### Building and Running with Docker
+
+You can run the server in a Docker container instead of installing Node.js
+locally. Build the image from the repository root:
+
+```bash
+docker build -t azure-devops-mcp .
+```
+
+Run the container with the required environment variables:
+
+```bash
+docker run --rm -it \
+  -e AZURE_DEVOPS_ORG_URL=https://dev.azure.com/your-organization \
+  -e AZURE_DEVOPS_AUTH_METHOD=azure-identity \
+  -e AZURE_DEVOPS_DEFAULT_PROJECT=your-project-name \
+  azure-devops-mcp
+```
+
+Include additional variables such as `AZURE_DEVOPS_PAT`, `AZURE_TENANT_ID`,
+`AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` as needed.
+
 ### Usage with Claude Desktop/Cursor AI
 
 To integrate with Claude Desktop or Cursor AI, add one of the following configurations to your configuration file.


### PR DESCRIPTION
## Summary
- add Dockerfile for Node 18 image
- ignore build artifacts with .dockerignore
- document how to build and run the Docker image with required env vars

## Testing
- `npm test` *(fails: jest not found)*