### PR TITLE
Add HTTP server with Swagger

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.git
+.vscode
+.idea
+dist
+coverage
+logs
+*.log
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+EXPOSE 10080
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,33 @@ The server uses a feature-based architecture where each feature area (like work-
 
 ### Running with NPX
 
+### Building and Running with Docker
+
+You can run the server in a Docker container instead of installing Node.js
+locally. Build the image from the repository root:
+
+```bash
+docker build -t azure-devops-mcp .
+```
+
+Run the container with the required environment variables:
+
+```bash
+docker run --rm -it \
+  -e AZURE_DEVOPS_ORG_URL=https://dev.azure.com/your-organization \
+  -e AZURE_DEVOPS_AUTH_METHOD=azure-identity \
+  -e AZURE_DEVOPS_DEFAULT_PROJECT=your-project-name \
+  -e MCP_HTTP_PORT=10080 \
+  azure-devops-mcp
+```
+
+When `MCP_HTTP_PORT` is set, the server starts an HTTP interface. Map the host
+port to the container port and open `http://localhost:10080/docs` to interact
+with the API using Swagger UI.
+
+Include additional variables such as `AZURE_DEVOPS_PAT`, `AZURE_TENANT_ID`,
+`AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` as needed.
+
 ### Usage with Claude Desktop/Cursor AI
 
 To integrate with Claude Desktop or Cursor AI, add one of the following configurations to your configuration file.
@@ -121,6 +148,7 @@ Key environment variables include:
 | `AZURE_CLIENT_ID`              | Azure AD application ID (for service principals)                                   | Only with service principals | -                |
 | `AZURE_CLIENT_SECRET`          | Azure AD client secret (for service principals)                                    | Only with service principals | -                |
 | `LOG_LEVEL`                    | Logging level (debug, info, warn, error)                                           | No                           | info             |
+| `MCP_HTTP_PORT`                | Port to start the optional HTTP server with Swagger UI                           | No                           | -           |
 
 ## Troubleshooting Authentication
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Azure DevOps MCP Server API",
+    "version": "1.0.0",
+    "description": "HTTP interface for the MCP server"
+  },
+  "paths": {
+    "/mcp": {
+      "post": {
+        "summary": "Send an MCP request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "MCP response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,10 @@
     "dotenv": "^16.3.1",
     "minimatch": "^10.0.1",
     "zod": "^3.24.2",
-    "zod-to-json-schema": "^3.24.5"
+    "zod-to-json-schema": "^3.24.5",
+    "express": "^5.0.1",
+    "swagger-ui-express": "^5.1.0",
+    "swagger-jsdoc": "^6.2.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,40 @@
+import express from 'express';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import swaggerUi from 'swagger-ui-express';
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Start an HTTP server exposing MCP endpoints and Swagger docs.
+ * @param server MCP server instance
+ * @param port Port to listen on
+ */
+export async function startHttpServer(server: Server, port: number): Promise<void> {
+  const app = express();
+  app.use(express.json());
+
+  // Load swagger document from docs/openapi.json
+  const specPath = path.join(__dirname, '../docs/openapi.json');
+  let spec: any = {};
+  try {
+    spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+  } catch (err) {
+    process.stderr.write(`Failed to read Swagger spec at ${specPath}: ${err}\n`);
+  }
+
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(spec));
+  app.get('/swagger.json', (_req, res) => res.json(spec));
+
+  app.post('/mcp', async (req, res) => {
+    try {
+      const response = await (server as any).handleRequest(req.body);
+      res.json(response);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.listen(port, () => {
+    process.stderr.write(`HTTP server listening on port ${port}\n`);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 
 import { createAzureDevOpsServer } from './server';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { startHttpServer } from './http-server';
 import dotenv from 'dotenv';
 import { AzureDevOpsConfig } from './shared/types';
 import { AuthenticationMethod } from './shared/auth/auth-factory';
@@ -74,11 +75,15 @@ async function main() {
     // Create the server with configuration
     const server = createAzureDevOpsServer(getConfig());
 
-    // Connect to stdio transport
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-
-    process.stderr.write('Azure DevOps MCP Server running on stdio\n');
+    const httpPort = process.env.MCP_HTTP_PORT;
+    if (httpPort) {
+      await startHttpServer(server, parseInt(httpPort, 10));
+    } else {
+      // Connect to stdio transport
+      const transport = new StdioServerTransport();
+      await server.connect(transport);
+      process.stderr.write('Azure DevOps MCP Server running on stdio\n');
+    }
   } catch (error) {
     process.stderr.write(`Error starting server: ${error}\n`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- expose port 10080 in Dockerfile
- start optional HTTP server when `MCP_HTTP_PORT` is set
- serve Swagger UI from `/docs`
- document HTTP usage and `MCP_HTTP_PORT` variable

## Testing
- `npm test` *(fails: jest not found)*